### PR TITLE
feat(lsp): add helm language server

### DIFF
--- a/lua/usr/lsp/helm-ls.lua
+++ b/lua/usr/lsp/helm-ls.lua
@@ -1,0 +1,22 @@
+local lspconfig = require('lspconfig')
+
+local border = {
+  { '┌', 'FloatBorder' },
+  { '─', 'FloatBorder' },
+  { '┐', 'FloatBorder' },
+  { '│', 'FloatBorder' },
+  { '┘', 'FloatBorder' },
+  { '─', 'FloatBorder' },
+  { '└', 'FloatBorder' },
+  { '│', 'FloatBorder' },
+}
+
+local handlers = {
+  ['textDocument/hover'] = vim.lsp.with(vim.lsp.handlers.hover, { border = border }),
+  ['textDocument/signatureHelp'] = vim.lsp.with(vim.lsp.handlers.signature_help, { border = border }),
+}
+
+lspconfig.helm_ls.setup({
+  handlers = handlers,
+})
+

--- a/lua/usr/lsp/init.lua
+++ b/lua/usr/lsp/init.lua
@@ -7,4 +7,5 @@ require "usr.lsp.null-ls"
 require("usr.lsp.config")
 require('usr.lsp.mason')
 require('usr.lsp.setup')
+require('usr.lsp.helm-ls')
 -- require('usr.lsp.rttools')

--- a/lua/usr/lsp/mason.lua
+++ b/lua/usr/lsp/mason.lua
@@ -15,6 +15,7 @@ require('mason-lspconfig').setup({
         'azure_pipelines_ls',
         'bashls',
         'dockerls',
+        'helm_ls',
         'html',
         'jdtls',
         'jsonls',


### PR DESCRIPTION
## Summary
- add helm language server configuration
- load helm-ls in LSP init
- ensure helm_ls is installed by mason

## Testing
- `nvim --headless -c "lua require('usr.lsp.helm-ls')" -c "qa"` *(fails: command not found)*
- `apt-get install -y neovim` *(fails: Package 'neovim' has no installation candidate)*

------
https://chatgpt.com/codex/tasks/task_e_6894cff3ac18833184259203432a487d